### PR TITLE
Fix typo in box merge

### DIFF
--- a/lada/cli/remove_mosaic.py
+++ b/lada/cli/remove_mosaic.py
@@ -51,8 +51,13 @@ def cli():
     video_tmp_file_output_path = os.path.join(tempfile.gettempdir(), f"{os.path.basename(os.path.splitext(args.output)[0])}.tmp{os.path.splitext(args.output)[1]}")
     video_writer = VideoWriter(video_tmp_file_output_path, video_metadata.video_width, video_metadata.video_height, video_metadata.video_fps_exact, codec=args.codec, crf=args.crf, moov_front=args.moov_front, time_base=video_metadata.time_base)
 
-    for restored_frame, restored_frame_pts in tqdm(frame_restorer(), total=video_metadata.frames_count, desc="Processing frames"):
-        video_writer.write(restored_frame, restored_frame_pts, bgr2rgb=True)
+    try:
+        for restored_frame, restored_frame_pts in tqdm(frame_restorer(), total=video_metadata.frames_count, desc="Processing frames"):
+            video_writer.write(restored_frame, restored_frame_pts, bgr2rgb=True)
+    except (RuntimeError, StopIteration) as e:
+        print("Video processing stopped. Output video may be incomplete")
+        print("Exception caught : ")
+        print(e)
 
     video_writer.release()
 

--- a/lada/cli/remove_mosaic.py
+++ b/lada/cli/remove_mosaic.py
@@ -51,13 +51,8 @@ def cli():
     video_tmp_file_output_path = os.path.join(tempfile.gettempdir(), f"{os.path.basename(os.path.splitext(args.output)[0])}.tmp{os.path.splitext(args.output)[1]}")
     video_writer = VideoWriter(video_tmp_file_output_path, video_metadata.video_width, video_metadata.video_height, video_metadata.video_fps_exact, codec=args.codec, crf=args.crf, moov_front=args.moov_front, time_base=video_metadata.time_base)
 
-    try:
-        for restored_frame, restored_frame_pts in tqdm(frame_restorer(), total=video_metadata.frames_count, desc="Processing frames"):
-            video_writer.write(restored_frame, restored_frame_pts, bgr2rgb=True)
-    except (RuntimeError, StopIteration) as e:
-        print("Video processing stopped. Output video may be incomplete")
-        print("Exception caught : ")
-        print(e)
+    for restored_frame, restored_frame_pts in tqdm(frame_restorer(), total=video_metadata.frames_count, desc="Processing frames"):
+        video_writer.write(restored_frame, restored_frame_pts, bgr2rgb=True)
 
     video_writer.release()
 

--- a/lada/lib/mosaic_frames_generator.py
+++ b/lada/lib/mosaic_frames_generator.py
@@ -42,8 +42,8 @@ class Scene:
         current_box = self.data[-1][2]
         t = min(current_box[0], box[0])
         l = min(current_box[1], box[1])
-        b = min(current_box[2], box[2])
-        r = min(current_box[3], box[3])
+        b = max(current_box[2], box[2])
+        r = max(current_box[3], box[3])
         new_box = (t, l, b, r)
 
         current_mask = self.data[-1][1]


### PR DESCRIPTION
Fixed box merge logic to correctly merge the boxes into a larger box. Looks like a typo. Was causing mosaics to flash for a frame or causing some mosaics to not be cleaned when boxes were nearby one another.