### PR TITLE
Ensure ffprobe works on Ubuntu by using -print_format in get_video_meta_data

### DIFF
--- a/lada/lib/video_utils.py
+++ b/lada/lib/video_utils.py
@@ -87,7 +87,7 @@ class VideoReader:
         self.container.seek(offset)
 
 def get_video_meta_data(path: str) -> VideoMetadata:
-    cmd = ['ffprobe', '-v', 'quiet', '-output_format', 'json', '-select_streams', 'v', '-show_streams', '-show_format', path]
+    cmd = ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-select_streams', 'v', '-show_streams', '-show_format', path]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err =  p.communicate()
     if p.returncode != 0:


### PR DESCRIPTION
The ffprobe version available in Ubuntu’s package repositories (e.g., 4.4.x) typically supports only -print_format and its alias -of, but not -output_format. This is because earlier versions of the official source code and documentation primarily used -print_format as the standard argument, while -output_format is a newer alias mentioned in some recent documents but not implemented across all versions.

See #2 

There’s also a discrepancy between the official website and local man pages: while the FFmpeg website and some newer documentation reference -output_format, the version of ffprobe installed on Ubuntu—especially on LTS releases—often only recognizes -print_format, which can cause errors when using -output_format on these systems.

This PR updates the `ffprobe` command to use `-print_format` instead of `-output_format`.
This change ensures compatibility with different versions of ffprobe.

Reference:
https://manpages.ubuntu.com/manpages/focal/man1/ffprobe.1.html