### PR TITLE
fix: replace 8 bare excepts with except Exception

### DIFF
--- a/lada/gui/config/config.py
+++ b/lada/gui/config/config.py
@@ -500,7 +500,7 @@ class Config(GObject.Object):
         for custom_preset in custom_encoding_presets:
             try:
                 self._custom_encoding_presets.add(video_utils.EncodingPreset(custom_preset["name"], custom_preset["description"], True, custom_preset["encoder_name"], custom_preset["encoder_options"]))
-            except:
+            except Exception:
                 logger.warning(f"Couldn't parse custom preset '{custom_preset}' as EncodingPreset. Ignoring...")
 
     def validate_and_set_export_directory(self, export_directory: str | None):

--- a/lada/models/bpjdet/models/yolo.py
+++ b/lada/models/bpjdet/models/yolo.py
@@ -251,7 +251,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
         for j, a in enumerate(args):
             try:
                 args[j] = eval(a) if isinstance(a, str) else a  # eval strings
-            except:
+            except Exception:
                 pass
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain

--- a/lada/models/centerface/centerface.py
+++ b/lada/models/centerface/centerface.py
@@ -25,7 +25,7 @@ class CenterFace:
                 import onnx
                 import onnxruntime
                 backend = 'onnxrt'
-            except:
+            except Exception:
                 # TODO: Warn when using a --verbose flag
                 # print('Failed to import onnx or onnxruntime. Falling back to slower OpenCV backend.')
                 backend = 'opencv'

--- a/lada/models/dover/datasets/dover_datasets.py
+++ b/lada/models/dover/datasets/dover_datasets.py
@@ -385,7 +385,7 @@ class ViewDecompositionDataset(torch.utils.data.Dataset):
                             label = float(label)
                         filename = osp.join(self.data_prefix, filename)
                         self.video_infos.append(dict(filename=filename, label=label))
-            except:
+            except Exception:
                 #### No Label Testing
                 video_filenames = []
                 for (root, dirs, files) in os.walk(self.data_prefix, topdown=True):
@@ -424,7 +424,7 @@ class ViewDecompositionDataset(torch.utils.data.Dataset):
             data["frame_inds"] = frame_inds
             data["gt_label"] = label
             data["name"] = filename  # osp.basename(video_info["filename"])
-        except:
+        except Exception:
             # exception flow
             return {"name": filename}
 

--- a/lada/utils/mosaic_utils.py
+++ b/lada/utils/mosaic_utils.py
@@ -17,7 +17,7 @@ def get_mask_area_by_contour(mask):
     contours= cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)[0]
     try:
         area = cv2.contourArea(contours[0])
-    except:
+    except Exception:
         area = 0
     return area
 
@@ -25,7 +25,7 @@ def get_mask_area_by_bounding_box(mask):
     try:
         w, h = cv2.boundingRect(mask)[2:]
         area = w * h
-    except:
+    except Exception:
         area = 0
     return area
 

--- a/lada/utils/video_utils.py
+++ b/lada/utils/video_utils.py
@@ -503,7 +503,7 @@ class VideoWriter:
             out_packet = self.video_stream.encode(None)
             if out_packet:
                 self.output_container.mux(out_packet)
-        except:
+        except Exception:
             # TODO: For half of my test files flushing QSV encoders fail here with "Application provided invalid, non monotonically increasing dts to muxer in stream"
             # This doesn't happen with libx264 or NVENC encoders. The restored file plays fine so let's ignore it for now.
             if self.is_qsv_encoder:


### PR DESCRIPTION
Replace 8 bare `except:` with `except Exception:` across 6 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.