### PR TITLE
Tag HEVC output as hvc1 for all HEVC encoders in ISOBMFF containers

### DIFF
--- a/lada/utils/video_utils.py
+++ b/lada/utils/video_utils.py
@@ -441,8 +441,16 @@ class VideoWriter:
         video_stream_out.codec_context.time_base = time_base
 
         stream_options = self._parse_encoder_options(encoder_options)
-        # hevc_videotoolbox needs tag 'hvc1' for compatibility (e.g. Safari in MP4/MOV); preset -tag:v is often ignored by PyAV/ffmpeg
-        if encoder == 'hevc_videotoolbox':
+        # All HEVC encoders must tag the stream 'hvc1' in ISOBMFF containers
+        # (mp4/mov/m4v). ffmpeg defaults to 'hev1', which is spec-valid but
+        # rejected by Apple's AVFoundation — Finder thumbnails, QuickLook,
+        # QuickTime and Safari all refuse hev1-tagged HEVC. 'hvc1' is a
+        # metadata-only change with no effect on non-Apple players. This was
+        # previously limited to hevc_videotoolbox, so hevc_nvenc/libx265/etc.
+        # output silently broke on Apple. (-tag:v is often ignored by PyAV, so
+        # set it as a stream option here.)
+        hevc_encoders = ('libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox')
+        if encoder in hevc_encoders and output_path.lower().endswith(('.mp4', '.mov', '.m4v')):
             stream_options['tag'] = 'hvc1'
         video_stream_out.options = stream_options
         self.output_container = output_container


### PR DESCRIPTION
## Problem

`VideoWriter` only sets the `hvc1` codec tag for `hevc_videotoolbox`. ffmpeg defaults HEVC-in-MP4/MOV to the `hev1` tag, which is spec-valid but **rejected by Apple's AVFoundation** — Finder thumbnails, QuickLook, QuickTime Player and Safari all treat `hev1`-tagged HEVC as unsupported.

So restored output produced with `hevc_nvenc` (and `libx265` / `hevc_amf` / `hevc_qsv`) silently fails to preview/play on Apple platforms, while `hevc_videotoolbox` output works. We hit exactly this: NVENC-encoded restored `.mp4` files have no Finder thumbnail and won't QuickLook on macOS.

## Fix

Set `tag = 'hvc1'` for **every** HEVC encoder when the container is ISOBMFF (`.mp4` / `.mov` / `.m4v`), not just `hevc_videotoolbox`:

```python
hevc_encoders = ('libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox')
if encoder in hevc_encoders and output_path.lower().endswith(('.mp4', '.mov', '.m4v')):
    stream_options['tag'] = 'hvc1'
```

It's a **metadata-only** change (no re-encode, no quality/size impact), and non-Apple players accept both `hev1` and `hvc1`.

## Note on venue

I see the project's canonical home is Codeberg and GitHub is a mirror — apologies if PRs here aren't your preferred flow. Happy to re-open this on Codeberg; opening here since this is where my fork lives. The patch is a single small diff in `lada/utils/video_utils.py` and easy to cherry-pick.