### PR TITLE
Fix HEVC hvc1 tagging: set stream codec_tag and cover all HEVC encoders

### DIFF
--- a/lada/utils/video_utils.py
+++ b/lada/utils/video_utils.py
@@ -441,10 +441,15 @@ class VideoWriter:
         video_stream_out.codec_context.time_base = time_base
 
         stream_options = self._parse_encoder_options(encoder_options)
-        # hevc_videotoolbox needs tag 'hvc1' for compatibility (e.g. Safari in MP4/MOV); preset -tag:v is often ignored by PyAV/ffmpeg
-        if encoder == 'hevc_videotoolbox':
-            stream_options['tag'] = 'hvc1'
         video_stream_out.options = stream_options
+        # All HEVC encoders need tag 'hvc1' in ISOBMFF containers (mp4/mov/m4v) for Apple compatibility
+        # (Finder thumbnails, QuickLook, QuickTime, Safari). ffmpeg defaults to 'hev1', which AVFoundation
+        # rejects. Metadata-only change, non-Apple players accept both. The tag is the muxer FourCC and must
+        # be set via the stream's codec_tag; passing it through encoder options (stream.options) is silently
+        # ignored by PyAV/ffmpeg and leaves the output as 'hev1'.
+        hevc_encoders = ('libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox')
+        if encoder in hevc_encoders and output_path.lower().endswith(('.mp4', '.mov', '.m4v')):
+            video_stream_out.codec_tag = 'hvc1'
         self.output_container = output_container
         self.video_stream = video_stream_out
 


### PR DESCRIPTION
## Problem

HEVC output in ISOBMFF containers (mp4/mov/m4v) is tagged `hev1`, which Apple's AVFoundation rejects — no Finder thumbnails / QuickLook previews, and no playback in QuickTime or Safari. The intended tag is `hvc1`.

The current code sets this through the encoder options dict:

```python
if encoder == 'hevc_videotoolbox':
    stream_options['tag'] = 'hvc1'
video_stream_out.options = stream_options
```

But PyAV/ffmpeg treats `stream.options` as **encoder private options** and silently ignores an unknown `tag` key, so the output stays `hev1`. (#153 widens this to all HEVC encoders but keeps the same ineffective mechanism, so it doesn't actually change the tag either.)

## Verification (PyAV 16.1.0)

| approach | resulting `codec_tag_string` |
|---|---|
| `stream.options['tag'] = 'hvc1'` | `hev1` ❌ |
| `stream.codec_tag = 'hvc1'` | `hvc1` ✅ |
| no tag (default) | `hev1` |

Confirmed end-to-end through `VideoWriter` with both `libx265` and `hevc_nvenc`: the muxed output goes from `hev1` to `hvc1`.

## Fix

Set the tag via the stream's `codec_tag` (the muxer FourCC) instead of encoder options, and apply it to all HEVC encoders (`libx265`, `hevc_nvenc`, `hevc_amf`, `hevc_qsv`, `hevc_videotoolbox`) when writing mp4/mov/m4v. Metadata-only change; non-Apple players accept both tags.

Supersedes #153.
